### PR TITLE
closes #68: use clang-tidy cmake arg instead of ici flag to lint head…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: melodic, ROS_REPO: main, CLANG_TIDY: pedantic, TARGET_WORKSPACE: "$TARGET_REPO_PATH metapackage_dependencies.rosinstall"}
+          - {ROS_DISTRO: melodic, ROS_REPO: main, ADDITIONAL_DEBS: "clang-tidy-9", TARGET_CMAKE_ARGS: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy-9", TARGET_WORKSPACE: "$TARGET_REPO_PATH metapackage_dependencies.rosinstall"}
 
     runs-on: ubuntu-18.04
     steps:

--- a/uwrt_utils/include/uwrt_utils/uwrt_can.h
+++ b/uwrt_utils/include/uwrt_utils/uwrt_can.h
@@ -17,8 +17,9 @@ namespace uwrt_utils {
 class UWRTCANWrapper {
  public:
   explicit UWRTCANWrapper() = default;
-  explicit UWRTCANWrapper(std::string name, std::string interface_name, bool rcv_big_endian,
-                          int thread_sleep_millis = 10);
+  explicit UWRTCANWrapper(
+      std::string name, std::string interface_name, bool rcv_big_endian,
+      int thread_sleep_millis = 10);  // NOLINT(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
   explicit UWRTCANWrapper(const UWRTCANWrapper& to_copy) = delete;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor, bugprone-exception-escape)
   explicit UWRTCANWrapper(UWRTCANWrapper&& to_move);


### PR DESCRIPTION
…er files.

closes #68 