### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,3 @@ updates:
     reviewers:
       - "wmmc88"
       - "azumnanji"
-
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    pull-request-branch-name:
-      separator: "/"
-    assignees:
-      - "wmmc88"
-    reviewers:
-      - "wmmc88"
-      - "azumnanji"


### PR DESCRIPTION
remove dependabot submodule because we don't use git submodules in ros (use rosinstall files instead)