### PR TITLE
User/wmmc88/#111/diff drive controller watchdog bug

### DIFF
--- a/uwrt_mars_rover_control/cfg/control_loop.yaml
+++ b/uwrt_mars_rover_control/cfg/control_loop.yaml
@@ -1,5 +1,5 @@
 uwrt_mars_rover:
 
   rover_control_loop_real:
-    control_frequency: 50.0
-    controllers_watchdog_timeout: 1.0
+    control_frequency: 50.0 # hz
+    controllers_watchdog_timeout: 0.04 # seconds

--- a/uwrt_mars_rover_control/include/uwrt_mars_rover_control/uwrt_mars_rover_hw_control_loop.h
+++ b/uwrt_mars_rover_control/include/uwrt_mars_rover_control/uwrt_mars_rover_hw_control_loop.h
@@ -22,7 +22,7 @@ class MarsRoverHWControlLoop {
 
   virtual bool init();
 
-  void update(const ros::Time& time_now);
+  void update();
 
  protected:
   const std::string name_;
@@ -33,6 +33,7 @@ class MarsRoverHWControlLoop {
 
   std::unique_ptr<controller_manager::ControllerManager> controller_manager_;
 
+  ros::Time current_control_loop_time_;
   ros::Time last_control_loop_time_;
   double controller_watchdog_timeout_{0};
   double control_freq_{0};

--- a/uwrt_mars_rover_control/src/uwrt_mars_rover_control_loop_real.cpp
+++ b/uwrt_mars_rover_control/src/uwrt_mars_rover_control_loop_real.cpp
@@ -7,19 +7,13 @@ MarsRoverHWControlLoopReal::MarsRoverHWControlLoopReal(const ros::NodeHandle& nh
     ROS_ERROR_NAMED(name_, "Failed to initialize RobotHW");
     throw std::runtime_error("Failed to initialize RobotHW");
   }
-
-  // Get current time for initial update
-  ros::ros_steadytime(last_control_loop_time_.sec, last_control_loop_time_.nsec);
 }
 
 void MarsRoverHWControlLoopReal::runForeverBlocking() {
-  ros::Time current_time;
   ros::Rate rate(control_freq_);
 
   while (ros::ok()) {
-    // Use Monotonic Time
-    ros::ros_steadytime(current_time.sec, current_time.nsec);
-    this->update(current_time);
+    this->update();
     rate.sleep();
   }
 }

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/cfg/drivetrain_controllers.yaml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/cfg/drivetrain_controllers.yaml
@@ -17,7 +17,7 @@ uwrt_mars_rover:
     wheel_radius: 0.1524
 
     # Velocity commands timeout [s], default 0.5
-    cmd_vel_timeout: 1
+    cmd_vel_timeout: 0.5
 
     # TODO
     #  # Velocity and acceleration limits

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/drivers/roboteq_driver/external_config/Profile.xml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/drivers/roboteq_driver/external_config/Profile.xml
@@ -67,8 +67,8 @@
             <Nodes>
               <Node Text="USB/RS232 Safety">
                 <Nodes>
-                  <Node Text="Watchdog (ms)" Value="0">
-                    <Nodes />
+                  <Node Text="Watchdog (ms)" Value="100">
+                    <Nodes/>
                   </Node>
                 </Nodes>
               </Node>


### PR DESCRIPTION
This pr is blocked by #108 and #110. 

Only look at the diff from `6c1d640` and `75f0fcf`. The other commit is for changes in #108 and #110

This PR sets/changes the following timeouts for the drivetrain:

cmd_vel_timeout: 0.5 seconds 
controllers_watchdog_timeout: 0.04 seconds
roboteq watchdog: 0.1 seconds

cmd_vel_timeout -> this means 500ms of no received joystick input(running off the basestation laptop) before the diff_drive_controller(running on the rover) starts sending 0 vel commands. This somewhat large number is to account for any hiccups from spotty network connection. this used to be 1 second but now that i think about it, the rover can go 5+ metres in one second of no connection and that could be pretty bad (ex. inside the bay).

controllers_watchdog_timeout -> this means 0.04 seconds of no control loop running before resetting the controllers (ie. sending 0 command). This ros control loop is currently set to 50 hz so 0.04 seconds represents an update being late by over one whole entire update period (ie. 2/50 seconds). When this controller reset is triggered, it also has a ros warn to tell us that our control loop is going tooooooooo slow. if that happens, we probably need to get rid of code bloat or tighten deadlines/timings somewhere.

roboteq watchdog -> this means 0.1 seconds after the roboteq receives no can command, it will stop the motors. this is a parameter that is set in the profile.xml that we have to flash onto the roboteqs. one situation where this might trigger is if our can wiring gets disconnected or if our can bus is flooded with higher priority msgs.

I just sort of thought these would be reasonable numbers. feel free to suggest better ones!


This PR also fixes a long standing bug (from February) where the cmd_vel_timeout wasn't triggering (ie. our rover ran away from us when we lost network connection while filming for sar lol).

closes #111 