### PR TITLE
Closes CAN implementation issue - Upadhyaydhruv/fix can ros node

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "browse": {
+        "databaseFilename": "",
+        "limitSymbolsToIncludedHeaders": true
+      },
+      "includePath": [
+        "/home/dhruv/catkin_ws/devel/include/**",
+        "/opt/ros/melodic/include/**",
+        "/home/dhruv/catkin_ws/src/uwrt_mars_rover/uwrt_mars_rover_control/include/**",
+        "/home/dhruv/catkin_ws/src/uwrt_mars_rover/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/include/**",
+        "/home/dhruv/catkin_ws/src/uwrt_mars_rover/uwrt_mars_rover_neopixel/include/**",
+        "/home/dhruv/catkin_ws/src/uwrt_mars_rover/uwrt_mars_rover_utils/include/**",
+        "/usr/include/**"
+      ],
+      "name": "ROS"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/opt/ros/melodic/lib/python2.7/dist-packages"
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+/opt/ros/melodic/share/catkin/cmake/toplevel.cmake

--- a/uwrt_test_stress_can/CMakeLists.txt
+++ b/uwrt_test_stress_can/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.0.2)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/uwrt_test_stress_can/CMakeLists.txt
+++ b/uwrt_test_stress_can/CMakeLists.txt
@@ -1,3 +1,53 @@
-cmake_minimum_required(VERSION 3.0.2)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+cmake_minimum_required(VERSION 3.10.2)
+project(uwrt_test_stress_can)
+
+#load catkin required dependencies
+find_package(catkin REQUIRED COMPONENTS
+        roscpp
+    )
+
+
+
+find_package(catkin REQUIRED COMPONENTS
+    roscpp
+)
+
+catkin_package(
+        INCLUDE_DIRS
+        include
+        lib/uwrt_mars_rover_hw_bridge/include
+        LIBRARIES
+        ${PROJECT_NAME}
+        uwrt-mars-rover-hw-bridge
+        CATKIN_DEPENDS
+        roscpp
+)
+
+
+# Specify additional locations of header files
+include_directories(
+        include
+        ${catkin_INCLUDE_DIRS}
+)
+
+# Declare and link the C++ Library
+add_library(${PROJECT_NAME}
+        src/uwrt_can.cpp
+        src/uwrt_can_test_node.cpp
+        )
+
+install(TARGETS uwrt_test_stress_can
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )
+
+install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+        )
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h"
+        )

--- a/uwrt_test_stress_can/package.xml
+++ b/uwrt_test_stress_can/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+    <name>uwrt_test_stress_can</name>
+    <version>0.0.0</version>
+    <description>Package for testing new mechanism of sending CAN messages</description>
+
+    <maintainer email="dmupadhyay12@gmail.com">Dhruv Upadhyay</maintainer>
+
+    <license>MIT</license>
+
+    <buildtool_depend>catkin</buildtool_depend>
+
+    <depend>std_msgs</depend>
+
+    <build_depend>message_generation</build_depend>
+
+    <exec_depend>message_runtime</exec_depend>
+
+</package>

--- a/uwrt_test_stress_can/src/main.cpp
+++ b/uwrt_test_stress_can/src/main.cpp
@@ -1,5 +1,8 @@
 #include <ros/ros.h>
 #include <uwrt_mars_rover_utils/uwrt_can.h>
+#include <thread>
+#include <ctime>
+
 
 void sendCANMessages() {
     constexpr uint16_t CAN_ID = 0x123;
@@ -7,6 +10,7 @@ void sendCANMessages() {
     std::string can_interface = "can0";
     uwrt_mars_rover_utils::UWRTCANWrapper can_wrapper_int = uwrt_mars_rover_utils::UWRTCANWrapper("can_stress_test", can_interface, true);
     uint16_t msg = 0;
+
     for (int16_t msg = 0; msg < ITERATIONS; msg++) {
         if (can_wrapper_int.writeToID<uint16_t>(msg, CAN_ID)) {
             if (msg%100 == 0)
@@ -18,7 +22,19 @@ void sendCANMessages() {
     }
 }
 
+void taskTimer() {
+    using namespace std::chrono;
+    std::this_thread::sleep_for(duration(seconds(30)));
+
+}
+
 int main(int argc, char* argv[]) {
+    std::thread t1(&taskTimer);
+    sendCANMessages();
+    t1.join(); // Waits for the first thread to complete it's 30 second wait before starting sending of second set
+    std::thread t2(&taskTimer); 
+    sendCANMessages(); 
+    t2.join();
+
     ros::init(argc, argv, "uwrt_test_stress_can");
-    //TODO: Implement timer to prevent the function calls from exceeding 30 sec
 }

--- a/uwrt_test_stress_can/src/main.cpp
+++ b/uwrt_test_stress_can/src/main.cpp
@@ -1,0 +1,24 @@
+#include <ros/ros.h>
+#include <uwrt_mars_rover_utils/uwrt_can.h>
+
+void sendCANMessages() {
+    constexpr uint16_t CAN_ID = 0x123;
+    constexpr ITERATIONS = 1000;
+    std::string can_interface = "can0";
+    uwrt_mars_rover_utils::UWRTCANWrapper can_wrapper_int = uwrt_mars_rover_utils::UWRTCANWrapper("can_stress_test", can_interface, true);
+    uint16_t msg = 0;
+    for (int16_t msg = 0; msg < ITERATIONS; msg++) {
+        if (can_wrapper_int.writeToID<uint16_t>(msg, CAN_ID)) {
+            if (msg%100 == 0)
+                ROS_INFO_STREAM("Successfully sent int msg " << msg << " to id 0x123");
+        } else {
+            ROS_INFO_STREAM("Failed to send int msg " << msg << " to id 0x123")
+            exit(EXIT_FAILURE);
+        }        
+    }
+}
+
+int main(int argc, char* argv[]) {
+    ros::init(argc, argv, "uwrt_test_stress_can");
+    //TODO: Implement timer to prevent the function calls from exceeding 30 sec
+}


### PR DESCRIPTION
This is a ros node to send 2 sets of successive CAN messages as a PoC for a new method of receiving and processing CAN messages. I've tried to make it so each set of CAN messages is limited to 30 seconds, as that is what's done on the firmware side as well. Could someone possibly look over the implementation thus far? I've marked it as draft for now