### PR TITLE
add a uwrt_params::getLogger function that can be used in code without reference to a nodehandle

### DIFF
--- a/uwrt_mars_rover_control/include/uwrt_mars_rover_control/uwrt_mars_rover_hw_control_loop.h
+++ b/uwrt_mars_rover_control/include/uwrt_mars_rover_control/uwrt_mars_rover_hw_control_loop.h
@@ -39,8 +39,8 @@ class MarsRoverHWControlLoop {
   ros::Time current_control_loop_time_;
   ros::Time last_control_loop_time_;
 
-  double control_freq_{uwrt_mars_rover_utils::getParam(nh_, "control_frequency", DEFAULT_CONTROL_FREQUENCY, name_)};
+  double control_freq_{uwrt_mars_rover_utils::getParam(nh_, name_, "control_frequency", DEFAULT_CONTROL_FREQUENCY)};
   double controller_watchdog_timeout_{
-      uwrt_mars_rover_utils::getParam(nh_, "controllers_watchdog_timeout", DEFAULT_CONTROLLER_WATCHDOG_TIMEOUT, name_)};
+      uwrt_mars_rover_utils::getParam(nh_, name_, "controllers_watchdog_timeout", DEFAULT_CONTROLLER_WATCHDOG_TIMEOUT)};
 };
 }  // namespace uwrt_mars_rover_control

--- a/uwrt_mars_rover_control/src/uwrt_mars_rover_control_node.cpp
+++ b/uwrt_mars_rover_control/src/uwrt_mars_rover_control_node.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
 
   const bool default_realtime_mode = true;
   const bool use_realtime_kernel{
-      uwrt_mars_rover_utils::getParam(nh, "use_realtime_kernel", default_realtime_mode, node_name)};
+      uwrt_mars_rover_utils::getParam(nh, node_name, "use_realtime_kernel", default_realtime_mode)};
 
   if (use_realtime_kernel) {
     constexpr auto REALTIME_SCHEDULING_POLICY = SCHED_FIFO;

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/src/uwrt_mars_rover_drivetrain_hw_real.cpp
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_hw/src/uwrt_mars_rover_drivetrain_hw_real.cpp
@@ -16,7 +16,7 @@ bool UWRTMarsRoverDrivetrainHWReal::init(ros::NodeHandle &root_nh, ros::NodeHand
 
   // TODO: controller to switch the roboteq communication mode
   std::unique_ptr<roboteq::CanopenInterface> comm = std::make_unique<roboteq::CanopenInterface>(
-      roboteq_canopen_id_, uwrt_mars_rover_utils::getParam<std::string>(root_nh, "can_interface_name", "can0", name_));
+      roboteq_canopen_id_, uwrt_mars_rover_utils::getParam<std::string>(root_nh, name_, "can_interface_name", "can0"));
   motor_controller_ = std::make_unique<roboteq::RoboteqController>(std::move(comm));
   return true;
 }
@@ -84,7 +84,7 @@ void UWRTMarsRoverDrivetrainHWReal::write(const ros::Time & /*time*/, const ros:
 }
 
 bool UWRTMarsRoverDrivetrainHWReal::loadRoboteqConfigFromParamServer(ros::NodeHandle &robot_hw_nh) {
-  roboteq_canopen_id_ = uwrt_mars_rover_utils::getParam<int>(robot_hw_nh, "roboteq_canopen_id", 0x01, name_);
+  roboteq_canopen_id_ = uwrt_mars_rover_utils::getParam<int>(robot_hw_nh, name_, "roboteq_canopen_id", 0x01);
 
   // Get joint list info
   XmlRpc::XmlRpcValue joints_list;

--- a/uwrt_mars_rover_neopixel/src/uwrt_mars_rover_neopixel_node.cpp
+++ b/uwrt_mars_rover_neopixel/src/uwrt_mars_rover_neopixel_node.cpp
@@ -13,13 +13,13 @@ int main(int argc, char** argv) {
   ros::NodeHandle nh;
 
   // Use Service Parameters
-  const int loop_rate{uwrt_mars_rover_utils::getParam<int>(nh, "neopixel/loop_rate", DEFAULT_LOOP_RATE, NODE_NAME)};
+  const int loop_rate{uwrt_mars_rover_utils::getParam<int>(nh, NODE_NAME, "neopixel/loop_rate", DEFAULT_LOOP_RATE)};
   const std::string can_interface{
-      uwrt_mars_rover_utils::getParam(nh, "neopixel/can_interface", DEFAULT_CAN_INTERFACE, NODE_NAME)};
+      uwrt_mars_rover_utils::getParam(nh, NODE_NAME, "neopixel/can_interface", DEFAULT_CAN_INTERFACE)};
   const std::string log_filter{
-      uwrt_mars_rover_utils::getParam(nh, "neopixel/log_filter", DEFAULT_LOG_FILTER, NODE_NAME)};
-  const int neopixel_can_id_outgoing{uwrt_mars_rover_utils::getParam<int>(nh, "neopixel/can_id_outgoing",
-                                                                          DEFAULT_NEOPIXEL_CAN_ID_OUTGOING, NODE_NAME)};
+      uwrt_mars_rover_utils::getParam(nh, NODE_NAME, "neopixel/log_filter", DEFAULT_LOG_FILTER)};
+  const int neopixel_can_id_outgoing{uwrt_mars_rover_utils::getParam<int>(nh, NODE_NAME, "neopixel/can_id_outgoing",
+                                                                          DEFAULT_NEOPIXEL_CAN_ID_OUTGOING)};
 
   // Run the node
   Neopixel neopixel_node(nh, static_cast<uint8_t>(loop_rate), can_interface, log_filter,

--- a/uwrt_mars_rover_utils/CMakeLists.txt
+++ b/uwrt_mars_rover_utils/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
 # Declare and link the C++ Library
 add_library(${PROJECT_NAME}
         src/uwrt_can.cpp
-        src/uwrt_can_test_node.cpp
+        src/uwrt_params.cpp
         )
 
 # uwrt_can_test_node

--- a/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
+++ b/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
@@ -15,21 +15,22 @@ namespace uwrt_mars_rover_utils {
  * @return parameter from ROS parameter server, or default_value if parameter lookup fails
  */
 template <typename T>
-T getParam(const ros::NodeHandle& nh, const std::string& param_name, const T& default_value,
-           const std::string& logger_name) {
+T getParam(const ros::NodeHandle& nh, const std::string& logger_name, const std::string& param_name,
+           const T& default_value) {
   T retrieved_param;
   bool param_found = nh.param<T>(param_name, retrieved_param, default_value);
 
   const std::string absolute_parameter_name = nh.resolveName(param_name);
 
   if (param_found) {
-    ROS_DEBUG_STREAM_NAMED(
+    // getParam will usually be called in the init/constructor of nodes. Its useful to know what params are being used.
+    ROS_INFO_STREAM_NAMED(
         logger_name, "Loaded \"" << retrieved_param << "\" from " << absolute_parameter_name << " on parameter server");
   } else {
-    ROS_ERROR_STREAM_NAMED(logger_name,
-                           absolute_parameter_name
-                               << " could not be found and loaded from parameter server. Using default value of \""
-                               << default_value << "\"");
+    ROS_WARN_STREAM_NAMED(logger_name,
+                          absolute_parameter_name
+                              << " could not be found and loaded from parameter server. Using default value of \""
+                              << default_value << "\"");
   }
 
   return retrieved_param;
@@ -48,23 +49,6 @@ T getParam(const ros::NodeHandle& nh, const std::string& param_name, const T& de
  * @param nh nodehandle to derive a logger name from
  * @return derived logger name
  */
-std::string getLoggerName(ros::NodeHandle& nh) {
-  const std::string& nh_namespace{nh.getNamespace()};
-  std::size_t start_of_name_index = nh_namespace.rfind('/') + 1;
-
-  std::string logger_name = nh_namespace.substr(start_of_name_index);
-  if (logger_name.empty()) {
-    static unsigned number_of_unnamed_loggers = 0;
-    std::string fallback_logger_name{"UNNAMED_LOGGER_" + std::to_string(number_of_unnamed_loggers)};
-    ROS_ERROR_STREAM_NAMED("uwrt_params",
-                           "Failed to construct a valid logger name from NodeHandle. Using fallback of \""
-                               << fallback_logger_name << "\"");
-
-    logger_name = fallback_logger_name;
-    number_of_unnamed_loggers++;
-  }
-
-  return logger_name;
-}
+std::string getLoggerName(ros::NodeHandle& nh);
 
 }  // namespace uwrt_mars_rover_utils

--- a/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
+++ b/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
@@ -35,4 +35,36 @@ T getParam(const ros::NodeHandle& nh, const std::string& param_name, const T& de
   return retrieved_param;
 }
 
+/** getLoggerName - Determines a rosconsole logger name from a nodehandle. Uses the last part of a nodehandles
+ * namespace.
+ *
+ * @example
+ * \code{.cpp}
+ * ros::NodeHandle nh("/a/b/c");
+ * std::string logger_name = uwrt_mars_rover_utils::getLoggerName(nh);
+ * // logger_name is equal to "c"
+ * \endcode
+ *
+ * @param nh nodehandle to derive a logger name from
+ * @return derived logger name
+ */
+std::string getLoggerName(ros::NodeHandle& nh) {
+  const std::string& nh_namespace{nh.getNamespace()};
+  std::size_t start_of_name_index = nh_namespace.rfind('/') + 1;
+
+  std::string logger_name = nh_namespace.substr(start_of_name_index);
+  if (logger_name.empty()) {
+    static unsigned number_of_unnamed_loggers = 0;
+    std::string fallback_logger_name{"UNNAMED_LOGGER_" + std::to_string(number_of_unnamed_loggers)};
+    ROS_ERROR_STREAM_NAMED("uwrt_params",
+                           "Failed to construct a valid logger name from NodeHandle. Using fallback of \""
+                               << fallback_logger_name << "\"");
+
+    logger_name = fallback_logger_name;
+    number_of_unnamed_loggers++;
+  }
+
+  return logger_name;
+}
+
 }  // namespace uwrt_mars_rover_utils

--- a/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
+++ b/uwrt_mars_rover_utils/include/uwrt_mars_rover_utils/uwrt_params.h
@@ -36,7 +36,7 @@ T getParam(const ros::NodeHandle& nh, const std::string& logger_name, const std:
   return retrieved_param;
 }
 
-/** getLoggerName - Determines a rosconsole logger name from a nodehandle. Uses the last part of a nodehandles
+/** getLoggerName - Determines a rosconsole logger name from a nodehandle. Uses the last part of a nodehandle's
  * namespace.
  *
  * @example
@@ -50,5 +50,12 @@ T getParam(const ros::NodeHandle& nh, const std::string& logger_name, const std:
  * @return derived logger name
  */
 std::string getLoggerName(ros::NodeHandle& nh);
+
+/** getLoggerName - Determines a rosconsole logger name by using the executing node's name. This is the name passed to
+ * ros::init
+ *
+ * @return derived logger name
+ */
+std::string getLoggerName();
 
 }  // namespace uwrt_mars_rover_utils

--- a/uwrt_mars_rover_utils/src/uwrt_params.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params.cpp
@@ -1,0 +1,22 @@
+#include <uwrt_mars_rover_utils/uwrt_params.h>
+
+namespace uwrt_mars_rover_utils {
+std::string getLoggerName(ros::NodeHandle& nh) {
+  const std::string& nh_namespace{nh.getNamespace()};
+  std::size_t start_of_name_index = nh_namespace.rfind('/') + 1;
+
+  std::string logger_name = nh_namespace.substr(start_of_name_index);
+  if (logger_name.empty()) {
+    static unsigned number_of_unnamed_loggers = 0;
+    std::string fallback_logger_name{"UNNAMED_LOGGER_" + std::to_string(number_of_unnamed_loggers)};
+    ROS_ERROR_STREAM_NAMED("uwrt_params",
+                           "Failed to construct a valid logger name from NodeHandle. Using fallback of \""
+                               << fallback_logger_name << "\"");
+
+    logger_name = fallback_logger_name;
+    number_of_unnamed_loggers++;
+  }
+
+  return logger_name;
+}
+}  // namespace uwrt_mars_rover_utils

--- a/uwrt_mars_rover_utils/src/uwrt_params.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params.cpp
@@ -9,7 +9,7 @@ std::string getLoggerName(ros::NodeHandle& nh) {
 
   std::string logger_name = nh_namespace.substr(start_of_name_index);
   if (logger_name.empty()) {
-    static unsigned number_of_unnamed_loggers = 0;
+    static unsigned int number_of_unnamed_loggers = 0;
     std::string fallback_logger_name{"UNNAMED_LOGGER_" + std::to_string(number_of_unnamed_loggers)};
     ROS_ERROR_STREAM_NAMED("uwrt_params",
                            "Failed to construct a valid logger name from NodeHandle. Using fallback of \""

--- a/uwrt_mars_rover_utils/src/uwrt_params.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params.cpp
@@ -1,6 +1,8 @@
+#include <ros/console.h>
 #include <uwrt_mars_rover_utils/uwrt_params.h>
 
 namespace uwrt_mars_rover_utils {
+
 std::string getLoggerName(ros::NodeHandle& nh) {
   const std::string& nh_namespace{nh.getNamespace()};
   std::size_t start_of_name_index = nh_namespace.rfind('/') + 1;
@@ -19,4 +21,13 @@ std::string getLoggerName(ros::NodeHandle& nh) {
 
   return logger_name;
 }
+
+std::string getLoggerName() {
+  std::string logger_name = ros::this_node::getName();
+  std::size_t start_of_name_index = logger_name.rfind('/') + 1;
+  logger_name = logger_name.substr(start_of_name_index);
+
+  return logger_name;
+}
+
 }  // namespace uwrt_mars_rover_utils

--- a/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
@@ -23,13 +23,13 @@ void getParamTest() {
 
   // Test successful param retrieval
   std::string retrieved_param =
-      uwrt_mars_rover_utils::getParam<std::string>(nh, PARAM_KEY, DEFAULT_PARAM_VALUE, NODE_NAME);
+      uwrt_mars_rover_utils::getParam<std::string>(nh, NODE_NAME, PARAM_KEY, DEFAULT_PARAM_VALUE);
   assert(PARAM_VALUE == retrieved_param);
 
   // Test unsuccessful param retrieval w/ custom logger name
   // This should return default because PARAM_KEY was not set in nh2's namespace
   retrieved_param =
-      uwrt_mars_rover_utils::getParam<std::string>(nh2, PARAM_KEY, DEFAULT_PARAM_VALUE, CUSTOM_LOGGER_NAME);
+      uwrt_mars_rover_utils::getParam<std::string>(nh2, CUSTOM_LOGGER_NAME, PARAM_KEY, DEFAULT_PARAM_VALUE);
   assert(DEFAULT_PARAM_VALUE == retrieved_param);
 }
 
@@ -55,15 +55,6 @@ void getLoggerNameTest() {
 
 int main(int argc, char* argv[]) {
   ros::init(argc, argv, NODE_NAME);
-
-  // Set loggers to print debug statements
-  bool success = ros::console::set_logger_level(std::string(ROSCONSOLE_DEFAULT_NAME) + '.' + NODE_NAME,
-                                                ros::console::levels::Debug);
-  assert(success);
-  success = ros::console::set_logger_level(std::string(ROSCONSOLE_DEFAULT_NAME) + '.' + CUSTOM_LOGGER_NAME,
-                                           ros::console::levels::Debug);
-  assert(success);
-  ros::console::notifyLoggerLevelsChanged();
 
   getParamTest();
   getLoggerNameTest();

--- a/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
@@ -51,6 +51,10 @@ void getLoggerNameTest() {
 
   logger_name = uwrt_mars_rover_utils::getLoggerName(nh);
   assert("UNNAMED_LOGGER_2" == logger_name);
+
+  // Should use node executable name when called without a nodehandle
+  logger_name = uwrt_mars_rover_utils::getLoggerName();
+  assert(NODE_NAME == logger_name);
 }
 
 int main(int argc, char* argv[]) {

--- a/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
+++ b/uwrt_mars_rover_utils/src/uwrt_params_test_node.cpp
@@ -11,10 +11,50 @@ static const std::string PARAM_KEY{"test_param"};
 static const std::string PARAM_VALUE{"This is a test string param value!"};
 static const std::string DEFAULT_PARAM_VALUE{"This is the DEFAULT string param value!"};
 
-int main(int argc, char* argv[]) {
-  ros::init(argc, argv, NODE_NAME);
+void getParamTest();
+void getLoggerNameTest();
+
+void getParamTest() {
   ros::NodeHandle nh;
   ros::NodeHandle nh2(nh, CUSTOM_NAMESPACE);
+
+  // Set param in nh namespace
+  nh.setParam(PARAM_KEY, PARAM_VALUE);
+
+  // Test successful param retrieval
+  std::string retrieved_param =
+      uwrt_mars_rover_utils::getParam<std::string>(nh, PARAM_KEY, DEFAULT_PARAM_VALUE, NODE_NAME);
+  assert(PARAM_VALUE == retrieved_param);
+
+  // Test unsuccessful param retrieval w/ custom logger name
+  // This should return default because PARAM_KEY was not set in nh2's namespace
+  retrieved_param =
+      uwrt_mars_rover_utils::getParam<std::string>(nh2, PARAM_KEY, DEFAULT_PARAM_VALUE, CUSTOM_LOGGER_NAME);
+  assert(DEFAULT_PARAM_VALUE == retrieved_param);
+}
+
+void getLoggerNameTest() {
+  ros::NodeHandle nh;
+  ros::NodeHandle nh2(nh, CUSTOM_NAMESPACE);
+
+  // NodeHandles with a global root namespace will return an "UNNAMED_LOGGER"
+  std::string logger_name{uwrt_mars_rover_utils::getLoggerName(nh)};
+  assert("UNNAMED_LOGGER_0" == logger_name);
+
+  // All other NodeHandles will return the last part of the namespace as the logger
+  logger_name = uwrt_mars_rover_utils::getLoggerName(nh2);
+  assert(CUSTOM_NAMESPACE == logger_name);
+
+  // Subsequent calls to getLoggerName with global root namespaces will increment the number after "UNNAMED_LOGGER".
+  logger_name = uwrt_mars_rover_utils::getLoggerName(nh);
+  assert("UNNAMED_LOGGER_1" == logger_name);
+
+  logger_name = uwrt_mars_rover_utils::getLoggerName(nh);
+  assert("UNNAMED_LOGGER_2" == logger_name);
+}
+
+int main(int argc, char* argv[]) {
+  ros::init(argc, argv, NODE_NAME);
 
   // Set loggers to print debug statements
   bool success = ros::console::set_logger_level(std::string(ROSCONSOLE_DEFAULT_NAME) + '.' + NODE_NAME,
@@ -25,18 +65,8 @@ int main(int argc, char* argv[]) {
   assert(success);
   ros::console::notifyLoggerLevelsChanged();
 
-  // Set param in nh namespace
-  nh.setParam(PARAM_KEY, PARAM_VALUE);
-
-  // Test successful param retrieval
-  std::string retrieved_param =
-      uwrt_mars_rover_utils::getParam<std::string>(nh, PARAM_KEY, DEFAULT_PARAM_VALUE, NODE_NAME);
-  assert(PARAM_VALUE == retrieved_param);
-
-  // Test unsuccessful param retrieval. This should return default because PARAM_KEY was not set in nh2's namespace
-  retrieved_param =
-      uwrt_mars_rover_utils::getParam<std::string>(nh2, PARAM_KEY, DEFAULT_PARAM_VALUE, CUSTOM_LOGGER_NAME);
-  assert(DEFAULT_PARAM_VALUE == retrieved_param);
+  getParamTest();
+  getLoggerNameTest();
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
closes #123 

While working on changes to  #84, I made some changes to `uwrt_params.h` with these getLogger functions. Decided it was a good idea to cherrypick these into their own pr so that @niiquaye can use them in #120 