### PR TITLE
Fix Broken CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,7 +198,7 @@ jobs:
           New-Item -Path C:/ci/ws/install/include -ItemType Directory
         # This is required because the windows binary builds used by setup-ros have the following issue:
         # `Imported target "rclcpp::rclcpp" includes non-existent path`
-        # This can be removed once https://github.com/ros2/ros2/issues/1068 and https://github.com/ros2/rclcpp/issues/1688 are resolved.
+        # This can be removed once https://github.com/ros2/ros2/issues/1068 and https://github.com/ros2/rclcpp/issues/1688 are resolved and released
 
       - name: Build ROS2 Packages and Run Tests
         uses: ros-tooling/action-ros-ci@v0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@0.2
+        uses: ros-tooling/setup-ros@v0.2
         with:
           required-ros-distributions: ${{ env.ROS_DISTRO }}
 
@@ -201,7 +201,7 @@ jobs:
         # This can be removed once https://github.com/ros2/ros2/issues/1068 and https://github.com/ros2/rclcpp/issues/1688 are resolved.
 
       - name: Build ROS2 Packages and Run Tests
-        uses: ros-tooling/action-ros-ci@0.2
+        uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           vcs-repo-file-url: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,14 +182,14 @@ jobs:
             colcon test --packages-select ${{ env.PACKAGES_TO_TEST }} --return-code-on-test-failure --event-handlers console_cohesion+"
 
   windows-amd64-build-and-test: # No rostooling/setup-ros-docker docker images available for Windows.
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@master # v0.2 doesn't have commit 45f6b7f which is required for Windows builds
+        uses: ros-tooling/setup-ros@0.2
         with:
           required-ros-distributions: ${{ env.ROS_DISTRO }}
 
@@ -201,7 +201,7 @@ jobs:
         # This can be removed once https://github.com/ros2/ros2/issues/1068 and https://github.com/ros2/rclcpp/issues/1688 are resolved.
 
       - name: Build ROS2 Packages and Run Tests
-        uses: wmmc88/action-ros-ci@wmmc88/fix-windows-builds # Revert to upstream action-ros-ci once https://github.com/ros-tooling/action-ros-ci/pull/712 merges
+        uses: ros-tooling/action-ros-ci@0.2
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           vcs-repo-file-url: |

--- a/windows_amd64_upstream_dependencies.repos
+++ b/windows_amd64_upstream_dependencies.repos
@@ -5,10 +5,6 @@ repositories:
     type: git
     url: https://github.com/ros/angles.git
     version: 1.12.4 # Latest release tag, no distro branch available
-  ament_cmake: # TODO: remove to revert back to ament_cmake in ros_base once https://github.com/ament/ament_cmake/issues/373 is resolved and a new windows galactic binary is released (Patch 2?)
-    type: git
-    url: https://github.com/ament/ament_cmake.git
-    version: galactic
   joint_state_publisher:
     type: git
     url: https://github.com/ros/joint_state_publisher.git

--- a/windows_amd64_upstream_dependencies.repos
+++ b/windows_amd64_upstream_dependencies.repos
@@ -13,6 +13,14 @@ repositories:
     type: git
     url: https://github.com/ros/joint_state_publisher.git
     version: ros2
+  rcutils:
+    type: git
+    url: https://github.com/ros2/rcutils.git
+    version: galactic
+  rcpputils:
+    type: git
+    url: https://github.com/ros2/rcpputils.git
+    version: galactic
   xacro:
     type: git
     url: https://github.com/wmmc88/xacro.git # FORK. TODO: switch back to ros2 branch on upstream once https://github.com/ros/xacro/pull/304 merges and releases

--- a/windows_amd64_upstream_dependencies.repos
+++ b/windows_amd64_upstream_dependencies.repos
@@ -1,10 +1,6 @@
 # These are upstream source dependencies used by windows amd64 builds.
 
 repositories:
-  angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: 1.12.4 # Latest release tag, no distro branch available
   joint_state_publisher:
     type: git
     url: https://github.com/ros/joint_state_publisher.git

--- a/windows_amd64_upstream_dependencies.repos
+++ b/windows_amd64_upstream_dependencies.repos
@@ -1,6 +1,10 @@
 # These are upstream source dependencies used by windows amd64 builds.
 
 repositories:
+  ament_cmake: # TODO: remove to revert back to ament_cmake in ros_base once a new windows galactic binary is released (ROS 2 Galactic Geochelone - Patch Release 2) at https://github.com/ros2/ros2/releases
+    type: git
+    url: https://github.com/ament/ament_cmake.git
+    version: galactic
   joint_state_publisher:
     type: git
     url: https://github.com/ros/joint_state_publisher.git

--- a/windows_amd64_upstream_dependencies.repos
+++ b/windows_amd64_upstream_dependencies.repos
@@ -25,8 +25,8 @@ repositories:
   # From https://github.com/ros-controls/ros2_control/blob/galactic/ros2_control/ros2_control.repos
   ros-controls/ros2_control:
     type: git
-    url: https://github.com/wmmc88/ros2_control.git # FORK. TODO: switch back to galactic branch on upstream once https://github.com/ros-controls/ros2_control/pull/607 merges and releases
-    version: wmmc88/controller-manager-console-scripts # galactic
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
   ros-controls/ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
@@ -34,7 +34,7 @@ repositories:
   ros-controls/realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
-    version: foxy-devel # foxy, galactic and rolling all release from foxy-devel
+    version: foxy-devel
   ros-controls/control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
CI builds have been broken for a couple weeks due to and upstream issue. Upreving CI stages to updated versions with fixes implemented + going back to upstream versions since my changes have been merged usptream.

revert to upstream setup-ros and action-ros-ci since windows fixes have merged. pin to windows-2019