### PR TITLE
PERCEPTION: Setting up sensors

### DIFF
--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/CMakeLists.txt
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(uwrt_mars_rover_drivetrain_description)
 
 find_package(ament_cmake REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 install(
     DIRECTORY
@@ -9,6 +10,7 @@ install(
       launch
       rviz
       urdf
+      world
     DESTINATION
       share/${PROJECT_NAME}
 )

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
@@ -1,0 +1,46 @@
+depth_camera:
+  camera1:
+    dim:
+      length: 0.05
+      width: 0.05
+      height: 0.05
+    parent_link: chassis
+    offset:
+      x: 0
+      y: 0
+      z: 0.1
+
+      r_rot: 0
+      p_rot: 0
+      y_rot: 0
+
+  camera2:
+    dim:
+      length: 0.05
+      width: 0.05
+      height: 0.05
+    parent_link: chassis
+    offset:
+      x: 0.585
+      y: 0
+      z: 0.1
+      
+      r_rot: 0
+      p_rot: 0
+      y_rot: 0
+
+lidar:
+  lidar1:
+    dim:
+      length: 0.05
+      width: 0.05
+      height: 0.05
+    parent_link: chassis
+    offset:
+      x: 0.4
+      y: 0.3
+      z: 0.1
+
+      r_rot: 0
+      p_rot: 0
+      y_rot: 0

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
@@ -36,7 +36,7 @@ depth_camera:
 
       r_rot: 0
       p_rot: 0
-      y_rot: 3.14159265359pi
+      y_rot: 3.14159265359
     camera_properties:
       horizontal_fov: 1.047198
       image:
@@ -55,8 +55,8 @@ lidar:
       height: 0.05
     parent_link: chassis
     offset:
-      x: 0.4
-      y: 0.3
+      x: 0.61
+      y: 0
       z: 0.1
 
       r_rot: 0

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/config/sensor_parameters.yaml
@@ -6,13 +6,22 @@ depth_camera:
       height: 0.05
     parent_link: chassis
     offset:
-      x: 0
+      x: 0.61
       y: 0
-      z: 0.1
+      z: 0
 
       r_rot: 0
       p_rot: 0
       y_rot: 0
+    camera_properties:
+      horizontal_fov: 1.047198
+      image:
+        width: 640
+        height: 480
+        format: R8G8B8
+      clip:
+        near: 0.05
+        far: 3
 
   camera2:
     dim:
@@ -21,13 +30,22 @@ depth_camera:
       height: 0.05
     parent_link: chassis
     offset:
-      x: 0.585
+      x: -0.61
       y: 0
-      z: 0.1
-      
+      z: 0
+
       r_rot: 0
       p_rot: 0
-      y_rot: 0
+      y_rot: 3.14159265359pi
+    camera_properties:
+      horizontal_fov: 1.047198
+      image:
+        width: 640
+        height: 480
+        format: R8G8B8
+      clip:
+        near: 0.05
+        far: 3
 
 lidar:
   lidar1:
@@ -44,3 +62,15 @@ lidar:
       r_rot: 0
       p_rot: 0
       y_rot: 0
+
+    lidar_properties:
+      update_rate: 5
+      scan:
+        samples: 360
+        resolution: 1.000000
+        min_angle: 0.000000
+        max_angle: 6.280000
+      range:
+        min: 0.120000
+        max: 3.5
+        resolution: 0.015000

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/launch/gazebo.launch.py
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/launch/gazebo.launch.py
@@ -6,6 +6,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 import xacro
 
 
@@ -15,6 +16,8 @@ def generate_launch_description():
     pkg_name = 'uwrt_mars_rover_drivetrain_description'
     file_subpath = 'urdf/drivetrain.urdf.xacro'
 
+    pkg_share = FindPackageShare(package=pkg_name).find(pkg_name)
+    world_path=os.path.join(pkg_share, 'world/my_world.sdf')
 
     # Use xacro to process the file
     xacro_file = os.path.join(get_package_share_directory(pkg_name),file_subpath)

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/package.xml
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
@@ -48,9 +48,12 @@
   <xacro:property name="sensors_parameters" value="${load_yaml(sensor_paramater_file)}"/>
 
   <xacro:generate_sensor_frame sensor_params="${sensors_parameters['depth_camera']['camera1']}" name="camera1"/>
-  <xacro:default_depth_camera_frame camera_link_name="camera1"/>
+  <xacro:default_depth_camera_frame camera_link_name="camera1" camera_props="${sensors_parameters['depth_camera']['camera1']['camera_properties']}"/>
   
-  <xacro:generate_sensor_frame sensor_params="${sensors_parameters['lidar']['lidar1']}"         name="lidar1"/>
-  <xacro:default_lidar_frame lidar_link_name="lidar1"/>
+  <xacro:generate_sensor_frame sensor_params="${sensors_parameters['depth_camera']['camera2']}" name="camera2"/>
+  <xacro:default_depth_camera_frame camera_link_name="camera2" camera_props="${sensors_parameters['depth_camera']['camera2']['camera_properties']}"/>
+
+  <!-- <xacro:generate_sensor_frame sensor_params="${sensors_parameters['lidar']['lidar1']}"         name="lidar1"/>
+  <xacro:default_lidar_frame lidar_link_name="lidar1" lidar_props="${sensors_parameters['lidar']['lidar1']['lidar_properties']}"/> -->
 
 </robot>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
@@ -53,7 +53,7 @@
   <xacro:generate_sensor_frame sensor_params="${sensors_parameters['depth_camera']['camera2']}" name="camera2"/>
   <xacro:default_depth_camera_frame camera_link_name="camera2" camera_props="${sensors_parameters['depth_camera']['camera2']['camera_properties']}"/>
 
-  <!-- <xacro:generate_sensor_frame sensor_params="${sensors_parameters['lidar']['lidar1']}"         name="lidar1"/>
-  <xacro:default_lidar_frame lidar_link_name="lidar1" lidar_props="${sensors_parameters['lidar']['lidar1']['lidar_properties']}"/> -->
+  <xacro:generate_sensor_frame sensor_params="${sensors_parameters['lidar']['lidar1']}"         name="lidar1"/>
+  <xacro:default_lidar_frame lidar_link_name="lidar1" lidar_props="${sensors_parameters['lidar']['lidar1']['lidar_properties']}"/>
 
 </robot>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/drivetrain.urdf.xacro
@@ -2,10 +2,13 @@
 <robot name="drivetrain" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!-- import macros file -->
   <xacro:include filename="$(find uwrt_mars_rover_drivetrain_description)/urdf/drivetrain.macro.xacro"/>
+  <xacro:include filename="$(find uwrt_mars_rover_drivetrain_description)/urdf/sensors.macro.xacro"/>
 
   <!-- load model data from yamls -->
   <xacro:load_model_data
       physical_parameters_file="$(find uwrt_mars_rover_drivetrain_description)/config/physical_parameters.yaml"/>
+    
+  <xacro:property name="sensor_paramater_file" value="$(find uwrt_mars_rover_drivetrain_description)/config/sensor_parameters.yaml"/>
 
   <!-- calculate parameters based on model data -->
   <xacro:property name="wheelbase_length" value="${chassis_width + wheel_width}"/>
@@ -39,5 +42,15 @@
   <xacro:wheel prefix="left" suffix="front" parent_link="chassis" reflect="1" x_position="${chassis_length/2}"/>
   <xacro:wheel prefix="left" suffix="middle" parent_link="chassis" reflect="1" x_position="0"/>
   <xacro:wheel prefix="left" suffix="back" parent_link="chassis" reflect="1" x_position="${-chassis_length/2}"/>
+
+
+  <!-- sensors -->
+  <xacro:property name="sensors_parameters" value="${load_yaml(sensor_paramater_file)}"/>
+
+  <xacro:generate_sensor_frame sensor_params="${sensors_parameters['depth_camera']['camera1']}" name="camera1"/>
+  <xacro:default_depth_camera_frame camera_link_name="camera1"/>
+  
+  <xacro:generate_sensor_frame sensor_params="${sensors_parameters['lidar']['lidar1']}"         name="lidar1"/>
+  <xacro:default_lidar_frame lidar_link_name="lidar1"/>
 
 </robot>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/sensors.macro.xacro
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/sensors.macro.xacro
@@ -29,30 +29,30 @@
   </xacro:macro>
 
 
-  <xacro:macro name="default_depth_camera_frame" params="camera_link_name">
+  <xacro:macro name="default_depth_camera_frame" params="camera_link_name camera_props">
     <gazebo reference="${camera_link_name}">
       <sensor name="${camera_link_name}_sensor" type="depth">
         <visualize>true</visualize>
         <update_rate>30.0</update_rate>
         <camera name="camera">
-          <horizontal_fov>1.047198</horizontal_fov>
+          <horizontal_fov>${camera_props['horizontal_fov']}</horizontal_fov>
           <image>
-            <width>640</width>
-            <height>480</height>
-            <format>R8G8B8</format>
+            <width>${camera_props['image']['width']}</width>
+            <height>${camera_props['image']['height']}</height>
+            <format>${camera_props['image']['format']}</format>
           </image>
           <clip>
-            <near>0.05</near>
-            <far>3</far>
+            <near>${camera_props['clip']['near']}</near>
+            <far>${camera_props['clip']['far']}</far>
           </clip>
         </camera>
         <plugin name="depth_camera_controller" filename="libgazebo_ros_camera.so">
           <cameraName>${camera_link_name}</cameraName>
-          <imageTopicName>ir/image_raw</imageTopicName>
-          <cameraInfoTopicName>ir/camera_info</cameraInfoTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <imageTopicName>${camera_link_name}_ir/image_raw</imageTopicName>
+          <cameraInfoTopicName>${camera_link_name}_ir/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>${camera_link_name}_depth/image_raw</depthImageTopicName>
+          <depthImageCameraInfoTopicName>${camera_link_name}_depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>${camera_link_name}_depth/points</pointCloudTopicName>
           <frameName>${camera_link_name}_optical_frame</frameName>
 
           <baseline>0.2</baseline>
@@ -76,25 +76,25 @@
     </gazebo>    
   </xacro:macro>
 
-  <xacro:macro name="default_lidar_frame" params="lidar_link_name">
+  <xacro:macro name="default_lidar_frame" params="lidar_link_name lidar_props">
     <gazebo reference="${lidar_link_name}">
     <sensor name="${lidar_link_name}_sensor" type="ray">
       <always_on>true</always_on>
       <visualize>true</visualize>
-      <update_rate>5</update_rate>
+      <update_rate>${lidar_props['update_rate']}</update_rate>
       <ray>
         <scan>
           <horizontal>
-            <samples>360</samples>
-            <resolution>1.000000</resolution>
-            <min_angle>0.000000</min_angle>
-            <max_angle>6.280000</max_angle>
+            <samples>${lidar_props['scan']['samples']}</samples>
+            <resolution>${lidar_props['scan']['resolution']}</resolution>
+            <min_angle>${lidar_props['scan']['min_angle']}</min_angle>
+            <max_angle>${lidar_props['scan']['max_angle']}</max_angle>
           </horizontal>
         </scan>
         <range>
-          <min>0.120000</min>
-          <max>3.5</max>
-          <resolution>0.015000</resolution>
+          <min>${lidar_props['range']['min']}</min>
+          <max>${lidar_props['range']['max']}</max>
+          <resolution>${lidar_props['range']['resolution']}</resolution>
         </range>
         <noise>
           <type>gaussian</type>
@@ -103,9 +103,6 @@
         </noise>
       </ray>
       <plugin name="lidar_controller" filename="libgazebo_ros_ray_sensor.so">
-        <ros>
-          <remapping>~/out:=${lidar_link_name}_sensor/scan</remapping>
-        </ros>
         <output_type>sensor_msgs/LaserScan</output_type>
         <frame_name>${lidar_link_name}</frame_name>
       </plugin>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/sensors.macro.xacro
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/urdf/sensors.macro.xacro
@@ -1,0 +1,116 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+
+  <!-- import macros file -->
+  <xacro:include filename="$(find uwrt_mars_rover_drivetrain_description)/urdf/drivetrain.macro.xacro"/>
+
+  <xacro:macro name="generate_sensor_frame" params="sensor_params name">
+    <link name="${name}">
+      <xacro:identical_visual_collision>
+        <identical_blocks>
+          <geometry>
+            <box size="${sensor_params['dim']['length']} ${sensor_params['dim']['width']} ${sensor_params['dim']['height']}"/>
+          </geometry>
+          <material name="blue">
+            <color rgba="0 0 0.8 1.0"/>
+          </material>
+        </identical_blocks>
+      </xacro:identical_visual_collision>
+      <xacro:default_inertial/>
+    </link>
+
+    <joint name="${sensor_params['parent_link']}_to_${name}" type="fixed">
+      <parent link="${sensor_params['parent_link']}"/>
+      <child link="${name}"/>
+      <origin xyz="${sensor_params['offset']['x']}     ${sensor_params['offset']['y']}     ${sensor_params['offset']['z']} " 
+              rpy="${sensor_params['offset']['r_rot']} ${sensor_params['offset']['p_rot']} ${sensor_params['offset']['y_rot']} "/>
+    </joint>
+
+  </xacro:macro>
+
+
+  <xacro:macro name="default_depth_camera_frame" params="camera_link_name">
+    <gazebo reference="${camera_link_name}">
+      <sensor name="${camera_link_name}_sensor" type="depth">
+        <visualize>true</visualize>
+        <update_rate>30.0</update_rate>
+        <camera name="camera">
+          <horizontal_fov>1.047198</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.05</near>
+            <far>3</far>
+          </clip>
+        </camera>
+        <plugin name="depth_camera_controller" filename="libgazebo_ros_camera.so">
+          <cameraName>${camera_link_name}</cameraName>
+          <imageTopicName>ir/image_raw</imageTopicName>
+          <cameraInfoTopicName>ir/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <frameName>${camera_link_name}_optical_frame</frameName>
+
+          <baseline>0.2</baseline>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>0.0</updateRate>
+          <frame_name>camera_depth_frame</frame_name>
+          <pointCloudCutoff>0.5</pointCloudCutoff>
+          <pointCloudCutoffMax>3.0</pointCloudCutoffMax>
+          <distortionK1>0</distortionK1>
+          <distortionK2>0</distortionK2>
+          <distortionK3>0</distortionK3>
+          <distortionT1>0</distortionT1>
+          <distortionT2>0</distortionT2>
+          <CxPrime>0</CxPrime>
+          <Cx>0</Cx>
+          <Cy>0</Cy>
+          <focalLength>0</focalLength>
+          <hackBaseline>0</hackBaseline>
+        </plugin>
+      </sensor>
+    </gazebo>    
+  </xacro:macro>
+
+  <xacro:macro name="default_lidar_frame" params="lidar_link_name">
+    <gazebo reference="${lidar_link_name}">
+    <sensor name="${lidar_link_name}_sensor" type="ray">
+      <always_on>true</always_on>
+      <visualize>true</visualize>
+      <update_rate>5</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>360</samples>
+            <resolution>1.000000</resolution>
+            <min_angle>0.000000</min_angle>
+            <max_angle>6.280000</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.120000</min>
+          <max>3.5</max>
+          <resolution>0.015000</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.01</stddev>
+        </noise>
+      </ray>
+      <plugin name="lidar_controller" filename="libgazebo_ros_ray_sensor.so">
+        <ros>
+          <remapping>~/out:=${lidar_link_name}_sensor/scan</remapping>
+        </ros>
+        <output_type>sensor_msgs/LaserScan</output_type>
+        <frame_name>${lidar_link_name}</frame_name>
+      </plugin>
+    </sensor>
+  </gazebo>
+  </xacro:macro>
+
+</robot>

--- a/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/world/my_world.sdf
+++ b/uwrt_mars_rover_drivetrain/uwrt_mars_rover_drivetrain_description/world/my_world.sdf
@@ -1,0 +1,242 @@
+<sdf version='1.7'>
+  <world name='default'>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <model name='ground_plane'>
+      <static>1</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>100</mu>
+                <mu2>50</mu2>
+              </ode>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <cast_shadows>0</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <wind/>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <latitude_deg>0</latitude_deg>
+      <longitude_deg>0</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <model name='unit_box'>
+      <pose>1.51271 -0.181418 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_sphere'>
+      <pose>-1.89496 2.36764 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <state world_name='default'>
+      <sim_time>0 0</sim_time>
+      <real_time>0 0</real_time>
+      <wall_time>1626668720 808592627</wall_time>
+      <iterations>0</iterations>
+      <model name='ground_plane'>
+        <pose>0 0 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box'>
+        <pose>1.51272 -0.181418 0.499995 0 1e-05 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>1.51272 -0.181418 0.499995 0 1e-05 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.010615 -0.006191 -9.78231 0.012424 0.021225 1.8e-05</acceleration>
+          <wrench>0.010615 -0.006191 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_sphere'>
+        <pose>-0.725833 1.36206 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-0.944955 1.09802 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>3.17226 -5.10401 6.58845 0 0.739643 2.19219</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
* in `drivetrain.urdf.xacro`, can use the macro `default_depth_camera_frame` or `default_lidar_frame` to simulate either a depth camera or lidar sensor in gazebo
* all sensor parameters such as dimension and relative position are in `sensor_parameters.yaml`

Gazebo showing the lidar rays from the sensor on one corner of the drivetrain (note there is a cube camera in the center of the drivetrain)
![Screenshot from 2023-09-13 22-43-08](https://github.com/uwrobotics/uwrt_mars_rover/assets/79111376/9e6f751c-1cd7-47f3-8aa3-f84f4ac441e7)

On RViz, these topics are used by the sensors, adding these topics to rviz will bring up a visual. (Note: if you get a "no image found" error, try https://github.com/ros-visualization/rqt/issues/187#issuecomment-810105698)
![Screenshot from 2023-09-13 22-45-53](https://github.com/uwrobotics/uwrt_mars_rover/assets/79111376/b517008a-85f4-4cf0-a0d2-3e9ee28a1c50)

For example image camera frame (we added some random objects in the world so there is something to "see")
![Screenshot from 2023-09-13 23-00-27](https://github.com/uwrobotics/uwrt_mars_rover/assets/79111376/3dee303f-66b4-4d8f-b131-1a00671e3c5a)

